### PR TITLE
Adding conformance t&c

### DIFF
--- a/process/conformance_terms_and_conditions.md
+++ b/process/conformance_terms_and_conditions.md
@@ -55,12 +55,12 @@ To achieve these objectives, The Linux Foundation requires that third parties wh
 
 In order to be a Participant in the Conformance Program and to use the Conformant Marks, a Participant must do the following:
 
-- Identify Offerings: determine those of its goods and services with which it intends to use the Conformance Marks
-Apply: submit a signed participation form to The Linux Foundation
-- Test: perform the tests specified in the Test Evaluation Guide on its designated goods and services
-- Submit Test Results: submit the results of tests (or, in the absence of a testing evaluation program, confirmations of conformance) to The Linux Foundation for review and verification
-- Successful Review: receive from The Linux Foundation confirmation that the test results have successfully passed or otherwise been accepted and the Qualifying Offerings are acknowledged as conformant. 
--Ongoing Conformance: continue to abide by the terms and conditions of the Conformance Program throughout the period of the Participant’s use of the Conformance Marks, including without limitation the specific requirements described below.
+- [Identify Offerings:](identify-offerings) determine those of its goods and services with which it intends to use the Conformance Marks
+- [Apply:](#apply) submit a signed participation form to The Linux Foundation
+- [Test:](#test) perform the tests specified in the Test Evaluation Guide on its designated goods and services
+- [Submit Test Results:](#submit-test-results) submit the results of tests (or, in the absence of a testing evaluation program, confirmations of conformance) to The Linux Foundation for review and verification
+- [Successful Review:](#successful-review) receive from The Linux Foundation confirmation that the test results have successfully passed or otherwise been accepted and the Qualifying Offerings are acknowledged as conformant. 
+- [Ongoing Conformance:](#ongoing-conformance) continue to abide by the terms and conditions of the Conformance Program throughout the period of the Participant’s use of the Conformance Marks, including without limitation the specific requirements described below.
 - Members of Open Mainframe Project will not be charged fees to participate in the Conformance Program. Other potential Participants should contact Open Mainframe Project for more information about participation fees.
 
 ## Process

--- a/process/conformance_terms_and_conditions.md
+++ b/process/conformance_terms_and_conditions.md
@@ -91,7 +91,7 @@ The participant must continue to abide by the terms and conditions of the Confor
 
 #### Conformance Test Versions
 
-Conformance for a Qualifying Offering is tied to a specific version of the corresponding conformance tests and evaluation criteria for one or more particular Components. The tests’ and evaluation criteria version number and the corresponding Component must be specified within the Conformance Mark logos, as described in the Visual Branding Guide. 
+Conformance for a Qualifying Offering is tied to a specific version of the corresponding conformance tests and evaluation criteria for one or more particular Components. The tests’ and evaluation criteria version number and the corresponding Component must be specified within the Conformance Mark logos, as described in the Visual Branding Guide. A previously-Qualifying Offering for a previous version can re-conform to the new Test Evaluation Guide to gain conformance to a newer version at any time by following the steps described above.  Being conformant to a version of Zowe does not roll over to conformance to later versions of Zowe, nor is conformance removed from a version of Zowe when a newer version is released, notwithstanding scenarios described in [Reported Non-conformance](#reported-non-conformance) and [Termination](#termination).  
 
 #### Reported Non-Conformance
 

--- a/process/conformance_terms_and_conditions.md
+++ b/process/conformance_terms_and_conditions.md
@@ -17,13 +17,13 @@
     - [Use of the Conformance Marks](#use-of-the-conformance-marks)
 - [Term and Termination](#term-and-termination)
     - [Term](#term)
-    - [Termination](#termnination)
+    - [Termination](#termination)
     - [Effect of termination](#effect-of-termination)
 - [Disclaimer of Warranties](#disclaimer-of-warranties)
 - [Limitation of Liability](#limitation-of-liability)
 - [Indemnification](#indemnification)
 - [Entire Agreement Modifications](#entire-agreement-modifications)
-- [Miscellaneous](#miscelaneous)
+- [Miscellaneous](#miscellaneous)
 
 ## Definitions
 

--- a/process/conformance_terms_and_conditions.md
+++ b/process/conformance_terms_and_conditions.md
@@ -1,0 +1,155 @@
+# Zowe Comformance Program Terms and Conditions
+
+- [Definitions](#definitions)
+- [Related Documents](#related-documents)
+- [Introduction](#introduction)
+    - [Participant Requirements](#participant-requirements)
+- [Process](#process)
+    - [Identify Offerings](#identify-offerings)
+    - [Apply](#apply)
+    - [Test](#test)
+    - [Submit test results](#submit-test-results)
+    - [Successful review](#successful-review)
+    - [Ongoing conformance](#ongoing-conformance)
+        - [Conformance Test Versions](#conformance-test-versions)
+        - [Reported Non-Conformance](#reported-non-conformance)
+        - [Removal of the Conformance Marks](#removal-of-the-conformance-marks)
+    - [Use of the Conformance Marks](#use-of-the-conformance-marks)
+- [Term and Termination](#term-and-termination)
+    - [Term](#term)
+    - [Termination](#termnination)
+    - [Effect of termination](#effect-of-termination)
+- [Disclaimer of Warranties](#disclaimer-of-warranties)
+- [Limitation of Liability](#limitation-of-liability)
+- [Indemnification](#indemnification)
+- [Entire Agreement Modifications](#entire-agreement-modifications)
+- [Miscellaneous](#miscelaneous)
+
+## Definitions
+
+In this document, these terms have the following meanings:
+
+- “Conformance Marks” means (1) the word mark “Zowe Conformant”, (2) the “Zowe Conformant” logo, and (3) all other logos and marks described in the Visual Branding Guide;
+- “Project Word Mark” means the trademark “Zowe”;
+- “Conformance Program” means the conformance, testing and trademark usage program described in this document;
+- “Participant” means a company or other entity that is permitted to use one or more of the Conformance Marks in association with their goods, services, pursuant to the Conformance Program;
+- “Qualifying Offering(s)” means a Participant’s goods or services that are conformant pursuant to the testing procedures described in the Test Evaluation Guide, where the conformance testing results or confirmations, as applicable have been submitted to and accepted by The Linux Foundation; and
+- “Component(s)” means each of (i) the Zowe API Mediation Layer, (ii) the Zowe CLI, (iii) the Zowe App Framework and (iv) any future technology included in the Zowe project that is designated as a “Component” in the Test Evaluation Guide.
+
+## Related Documents
+
+Together with these terms and conditions, the following documents are part of the Conformance Program, each as updated from time to time:
+
+- “Test Evaluation Guide”: the conformance testing instructions and requirements for the Conformance Program, available at https://www.openmainframeproject.org/projects/zowe/conformance/test-evaluation-guide;
+- “Visual Branding Guide”: the Conformance Program Visual Branding Guide, available at https://www.openmainframeproject.org/projects/zowe/conformance/branding-guide
+- “Trademark Usage Guidelines”: The Linux Foundation’s Trademark Usage Guidelines, available at https://www.linuxfoundation.org/trademark-usage/; and
+- “Participation Form”: the Conformance Program Participation Form, available at https://www.openmainframeproject.org/projects/zowe/conformance/participation-form-esign.
+
+# Introduction
+
+The Conformance Marks and the Project Word Mark are trademarks of The Linux Foundation. In connection with the Zowe community, The Linux Foundation has established the Conformance Program to achieve two objectives: 1) to ensure that the Conformance Marks and the Project Word Mark remain reliable indicators of the qualities that they have been created to preserve, and 2) to ensure that community members are able to accurately describe their Qualifying Offerings.
+
+To achieve these objectives, The Linux Foundation requires that third parties who use the Conformance Marks in association with their goods and services may do so only as Participants pursuant to the Conformance Program described in this document. By participating in the Conformance Program and by using the Conformance Marks, a Participant acknowledges that third parties will be relying on the accuracy of its self-testing results and confirmations and on its compliance with the terms of the Conformance Program.
+
+## Participant Requirements:
+
+In order to be a Participant in the Conformance Program and to use the Conformant Marks, a Participant must do the following:
+
+- Identify Offerings: determine those of its goods and services with which it intends to use the Conformance Marks
+Apply: submit a signed participation form to The Linux Foundation
+- Test: perform the tests specified in the Test Evaluation Guide on its designated goods and services
+- Submit Test Results: submit the results of tests (or, in the absence of a testing evaluation program, confirmations of conformance) to The Linux Foundation for review and verification
+- Successful Review: receive from The Linux Foundation confirmation that the test results have successfully passed or otherwise been accepted and the Qualifying Offerings are acknowledged as conformant. 
+-Ongoing Conformance: continue to abide by the terms and conditions of the Conformance Program throughout the period of the Participant’s use of the Conformance Marks, including without limitation the specific requirements described below.
+- Members of Open Mainframe Project will not be charged fees to participate in the Conformance Program. Other potential Participants should contact Open Mainframe Project for more information about participation fees.
+
+## Process
+
+### Identify Offerings
+
+The Participant should identify those of its goods and services, including specific version(s), with which it desires to use the Conformance Marks. These are the goods and services that will be subject to testing. The Participant should also determine the version(s) of the Zowe testing evaluation criteria that it intends to test against. Goods and services which have not previously been Qualifying Offerings must be tested against the most recent version of the Zowe testing evaluation criteria released by the Zowe project. If the evaluation criteria are successfully satisfied, and if the Participant fulfills the other requirements for the Conformance Program, then these goods and services are considered “Qualifying Offerings.”
+
+### Apply
+
+The Participant must submit a completed and signed Participation Form to The Linux Foundation via electronic signature at the Participation Form URL listed above or by any other method made available by The Linux Foundation. The Participation Form must designate the specific Qualifying Offering(s) that will be tested and include any other information requested on the Participation Form.
+
+### Test
+
+The Test Evaluation Guide contains details about the self-testing process and the specific tests that must be passed and criteria that must be satisfied for a Participant’s offering to be considered a Qualifying Offering. A Participant confirms that its goods and services are Qualifying Offerings by demonstrating that its offerings have successfully passed all of the tests and satisfied all of the criteria set forth in the Test Evaluation Guide. If the Zowe project makes available a testing evaluation program for the Conformance Program, then Participants must use the testing evaluation program to determine whether the tests are passed or failed. If the Zowe project has not made a testing evaluation program available, then the Participant should evaluate each of its potential Qualifying Offerings in accordance with the criteria set forth in the Test Evaluation Guide. 
+
+### Submit Test Results
+
+After passing the designated tests and satisfying the applicable criteria, a Participant must submit to The Linux Foundation a copy of the testing results generated by the testing evaluation program. If the Zowe project has not made a testing evaluation program available, then for each potential Qualifying Offering, the Participant must affirm its conformance as set forth on the Participation Form or other system of record made available by The Linux Foundation. These results may be made available to the public on the Zowe project website or other public repository if Participant makes public use of the Conformance Marks.
+
+### Successful Review
+
+If The Linux Foundation confirms to the Participant that the tests have been successfully passed and that the criteria in the Test Evaluation Guide have been satisfied, and if the other requirements for participant in the conformance program have been met, then the Participant may use the Program Marks with its Qualifying Offerings, subject to the usage requirements described below in the section entitled “Use of the Conformance Marks.” The Linux Foundation may share test results with members of the Zowe project community if The Linux Foundation deems it necessary and appropriate in connection with confirming that the tests have been passed or failed and that the criteria in the Test Evaluation Guide have been satisfied.
+
+### Ongoing Conformance
+
+The participant must continue to abide by the terms and conditions of the Conformance Program throughout the period of the Participant’s use of the Program Marks. This includes all of the terms set forth in this agreement, including without limitation the following specific requirements:
+
+#### Conformance Test Versions
+
+Conformance for a Qualifying Offering is tied to a specific version of the corresponding conformance tests and evaluation criteria for one or more particular Components. The tests’ and evaluation criteria version number and the corresponding Component must be specified within the Conformance Mark logos, as described in the Visual Branding Guide. 
+
+#### Reported Non-Conformance
+
+If The Linux Foundation subsequently determines or is informed that a Qualifying Offering does not successfully meet the evaluation criteria, then upon written notice from The Linux Foundation the Participant must address any non-conformance concerns raised by The Linux Foundation; successfully pass the corresponding tests and satisfy the applicable criteria; and submit to The Linux Foundation a copy of the new testing results generated by the testing evaluation program and/or confirmations of conformance, as applicable, within 30 days following such notice. Otherwise, the Participant will be subject to the requirements set forth below for removal of the Conformance Marks from that product or service.
+
+#### Removal of the Conformance Marks 
+
+Removal of the Conformance Marks at End of Conformance or Participation. If a Qualifying Offering ceases to remain conformant with the applicable tests and evaluation criteria, or upon any other termination of participation in the Conformance Program, a Participant may no longer use the Conformance Marks in new materials for that formerly Qualifying Offering, and must remove the Conformance Marks from existing marketing materials and websites for that formerly Qualifying Offering within 30 days.
+
+### Use of the Conformance Marks
+
+Use of the Conformance Marks is only permitted for Participants who have satisfied the requirements of the Conformance Program, and is only permitted in connection with its Qualifying Offerings. No other rights to use the Conformance Marks or the Project Word Mark are permitted hereunder, except to the extent permitted under “fair use” or other applicable law.
+
+All use of the Conformance Marks is subject to the Trademark Usage Guidelines, which are incorporated herein.
+
+Additionally, the following specific rules also apply to use of the Conformance Marks:
+
+- Do follow the requirements set forth in the Visual Branding Guide when using the Conformance Marks.
+- Do specify the version and Component of the Conformance Tests for which a Qualifying Offering has been tested, in a location near the Participant’s use of the Conformance Marks.
+- Do include appropriate notices of The Linux Foundation’s ownership of the Conformance Marks and the Project Word Mark. 
+- Do not use the Conformance Marks except as permitted pursuant to the Conformance Program’s terms. For example, do not use the Conformance Marks in connection with a service offering that is not itself a Qualifying Offering, or with a formerly Qualifying Offering whose conformance has terminated.
+- Do not be misleading about the nature or scope of certification or conformance.
+- Do not state or imply that the Participant’s participation in the Conformance Program constitutes The Linux Foundation’s endorsement of a Participant or its goods or services. For example, do not say that a Participant or a Qualifying Offering has been “certified by” The Linux Foundation or that The Linux Foundation “has certified Product XYZ”.
+- Do not state or imply that there are different degrees of certification or conformance. For example, do not say that a Qualifying Offering is “more certified” than another, or that it was “certified before” another Participant’s offerings.
+Participant Marks
+
+Each Participant hereby grants to The Linux Foundation a royalty-free, worldwide license to use and display the names and logos of Participant and its Qualifying Offerings (the “Participant Marks”) in connection with The Linux Foundation’s operation of the Conformance Program and its marketing and promotion of Participant’s participation in the Conformance Program. Each Participant represents and warrants that it possesses all rights necessary to make this license grant. The Linux Foundation will comply with any reasonable requirements regarding use of the Participant Marks about which the Participant notifies The Linux Foundation, and will correct any identified misuse within a reasonable time following Participant’s notification. Nothing in this section shall require The Linux Foundation to make any use of the Participant Marks. As between The Linux Foundation and Participant, any goodwill associated with the foregoing use of the Participant Marks shall inure to the benefit of the Participant.
+
+## Term and Termination
+
+### Term
+
+The term of a Participant’s participation in the Conformance Program shall begin upon the Participant’s submission of a Participation Form using the Participation Form URL listed above or by any other method made available by The Linux Foundation, and The Linux Foundation’s receipt and acceptance of a fully-completed Participation Form signed by the Participant.
+
+### Termination
+
+Either The Linux Foundation or the Participant may terminate Participant’s participation in the Conformance Program upon written notice to the other. Additionally, Participant’s participation in the Conformance Program shall automatically terminate (unless otherwise agreed by The Linux Foundation in writing) upon the occurrence of: (1) the Participant’s breach of the terms of the Conformance Program, if such breach is incurable or, if curable, is not cured within 15 days following written notice of breach; or (2) the cessation of conformance for all of the Participant’s Qualifying Offerings, if the Participant does not confirm any new Qualifying Offering within 30 days thereafter.
+
+### Effect of Termination
+
+Upon the termination of Participant’s participation in the Conformance Program, the Participant may no longer use the Conformance Marks and must remove them from existing marketing materials and websites. The sections of this agreement entitled “Participant Marks”, “Disclaimer of Warranties”, “Limitation of Liability”, “Indemnification”, and “Miscellaneous” shall survive any such termination.
+
+### Disclaimer of Warranties
+
+THE LINUX FOUNDATION MAKES NO EXPRESS OR IMPLIED WARRANTIES WITH RESPECT TO THE CONFORMANCE PROGRAM OR THE CONFORMANCE MARKS, EITHER TO PARTICIPANT OR TO ANY THIRD PARTY, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, OR NON-INFRINGEMENT OF ANY THIRD PARTY INTELLECTUAL PROPERTY RIGHTS. ANY DISCLAIMERS AND INDEMNITIES SET FORTH IN THE TRADEMARK USAGE GUIDELINES ARE ALSO DEEMED TO BE INCORPORATED HEREIN. A PARTICIPANT’S PARTICIPATION IN THE CONFORMANCE PROGRAM DOES NOT CONSTITUTE ANY FORM OF ENDORSEMENT BY THE LINUX FOUNDATION OF ANY PARTICIPANT OR ITS QUALIFYING OFFERINGS, AND THE LINUX FOUNDATION MAKES NO EXPRESS OR IMPLIED WARRANTIES WITH RESPECT THERETO. THE CONFORMANCE PROGRAM IS OFFERED “AS-IS”, “AS-AVAILABLE” AND “WITH ALL FAULTS.
+
+### Limitation of Liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, THE LINUX FOUNDATION SHALL NOT BE LIABLE FOR ANY DAMAGES, INCLUDING DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL, EXEMPLARY OR PUNITIVE DAMAGES, ARISING OUT OF OR RELATING TO THE CONFORMANCE PROGRAM OR ANY PARTICIPANT’S PARTICIPATION THEREIN. IF ANY DAMAGES ARE NOT EXCLUDED UNDER APPLICABLE LAW PURSUANT TO THE PRECEDING SENTENCE, THEN IN NO EVENT SHALL THE LINUX FOUNDATION’S LIABILITY FOR ANY SUCH DAMAGES EXCEED THE FEES PAID TO THE LINUX FOUNDATION BY THE PARTICIPANT SOLELY FOR PARTICIPATION IN THE CONFORMANCE PROGRAM. THE FOREGOING LIMITATIONS OF LIABILITY ARE AN ESSENTIAL BASIS OF THE DECISION TO OFFER THE CONFORMANCE PROGRAM AND THE PARTICIPANT’S PARTICIPATION THEREIN, AND SHALL APPLY REGARDLESS OF THE LEGAL THEORY UPON WHICH DAMAGES MAYBE CLAIMED; REGARDLESS OF WHETHER A PARTY KNEW OR SHOULD HAVE KNOWN OF THE POSSIBILITY OF SUCH DAMAGES; AND REGARDLESS OF WHETHER THE FOREGOING LIMITATIONS OF LIABILITY CAUSE ANY REMEDY TO FAIL IN ITS ESSENTIAL PURPOSE.
+
+### Indemnification
+
+By electing to participate in the Conformance Program or to make any use of the Conformance Marks, each Participant agrees to indemnify, defend and hold harmless The Linux Foundation, together with their affiliates and each of their respective employees, officers and directors (collectively, the “Indemnified Parties”) from and against any and all losses, liabilities, damages and penalties, and all related costs and expenses (including reasonable attorneys’ fees) arising from (1) the Participant’s breach of the terms of the Conformance Program, (2) any third party claims that may arise in any manner by reason of Participant’s use of the Conformance Marks with the Participant’s Qualifying Offerings or the Participant’s other goods and services, and (3) any third-party claim relating to the Participant’s Qualifying Offerings or the Participant’s other goods and services, including without limitation any product liability claim.
+
+### Entire Agreement Modifications
+
+These Terms and Conditions, together with the other documents referenced herein, constitute the entire agreement between any Participant and The Linux Foundation regarding Participant’s participation in the Conformance Program. These Terms and Conditions and the other documents referenced herein may be modified from time to time by The Linux Foundation, and updated versions will be placed on the Conformance Program website. Participant’s continued participation in the Conformance Program or continued use of the Conformance Marks constitutes Participant’s acceptance of all such modifications.
+
+### Miscellaneous
+
+All notices to be sent to The Linux Foundation hereunder should be sent to omp-zowe-conformance@lists.openmainframeproject.org, unless otherwise specified herein. The Conformance Program Terms and Conditions are governed by the law of the State of California, without regards to its choice of law provisions, and any action arising hereunder shall be brought in the state or federal courts located in California. The Participant and The Linux Foundation agree that the Conformance Program does not create a partnership or joint venture between them or any other Participant.

--- a/process/conformance_terms_and_conditions.md
+++ b/process/conformance_terms_and_conditions.md
@@ -55,7 +55,7 @@ To achieve these objectives, The Linux Foundation requires that third parties wh
 
 In order to be a Participant in the Conformance Program and to use the Conformant Marks, a Participant must do the following:
 
-- [Identify Offerings:](identify-offerings) determine those of its goods and services with which it intends to use the Conformance Marks
+- [Identify Offerings:](#identify-offerings) determine those of its goods and services with which it intends to use the Conformance Marks
 - [Apply:](#apply) submit a signed participation form to The Linux Foundation
 - [Test:](#test) perform the tests specified in the Test Evaluation Guide on its designated goods and services
 - [Submit Test Results:](#submit-test-results) submit the results of tests (or, in the absence of a testing evaluation program, confirmations of conformance) to The Linux Foundation for review and verification


### PR DESCRIPTION
Copying the Conformance program from https://wiki.zowe.org/display/ZCP/Zowe+Conformance+Program+Terms+and+Conditions to github.com/zlc for consistency/version control, ...

Changes from https://wiki.zowe.org/display/ZCP/Zowe+Conformance+Program+Terms+and+Conditions to this PR is to render in markdown text to assist with navigation between sections, and removal of the lines 
```
When a new version of the Test Evaluation Guide is released, conformant   
applications and services must demonstrate that they pass the updated   
tests and meet the updated evaluation criteria within 60 days. Applications    
that do not do so within the allotted time must  not be marked as conformant   
thereafter.
```
The removal was discussed and agreed at the onboarders squad and the ZLC meeting of March 4th asked for this to be put into github.com/zowe/zlc so that everyone could see and vote on the whether to approve the change.

After this PR is merged pending review, the onboarders squad will send an e-mail to zlc-private asking for a vote to the amendment.

For anyone doing a review if they click on  
![image](https://user-images.githubusercontent.com/28100302/76011765-0a492200-5f0d-11ea-81ca-f96d299c0da1.png)
 and then 
![image](https://user-images.githubusercontent.com/28100302/76011752-04534100-5f0d-11ea-89c2-13ad4c182c4e.png)
the browser will render the T&C in markdown preview mode